### PR TITLE
fix: Clean up code, fix Swift 6 concurrency warnings

### DIFF
--- a/Sources/CmdSpeak/Core/Audio/AudioCaptureManager.swift
+++ b/Sources/CmdSpeak/Core/Audio/AudioCaptureManager.swift
@@ -1,7 +1,6 @@
 import AVFoundation
 import Foundation
 
-/// Protocol for audio capture functionality.
 public protocol AudioCapturing: AnyObject {
     var isRecording: Bool { get }
     var onAudioBuffer: ((_ buffer: AVAudioPCMBuffer) -> Void)? { get set }
@@ -11,18 +10,11 @@ public protocol AudioCapturing: AnyObject {
     func requestPermission() async -> Bool
 }
 
-/// Manages microphone audio capture using AVAudioEngine.
-/// Captures 16kHz mono Float32 audio suitable for Whisper transcription.
 public final class AudioCaptureManager: AudioCapturing, @unchecked Sendable {
-    private let audioEngine = AVAudioEngine()
-    private var isSetup = false
+    private var audioEngine: AVAudioEngine?
 
     public private(set) var isRecording = false
     public var onAudioBuffer: ((_ buffer: AVAudioPCMBuffer) -> Void)?
-
-    /// Target format for Whisper: 16kHz mono Float32
-    private let targetSampleRate: Double = 16000
-    private let targetChannelCount: AVAudioChannelCount = 1
 
     public init() {}
 
@@ -42,84 +34,32 @@ public final class AudioCaptureManager: AudioCapturing, @unchecked Sendable {
             throw AudioCaptureError.permissionDenied
         }
 
-        try setupAudioEngine()
+        let engine = AVAudioEngine()
+        let inputNode = engine.inputNode
+        let format = inputNode.outputFormat(forBus: 0)
 
-        do {
-            try audioEngine.start()
-            isRecording = true
-        } catch {
-            throw AudioCaptureError.engineStartFailed(error)
-        }
-    }
-
-    public func stopRecording() {
-        guard isRecording else { return }
-
-        audioEngine.inputNode.removeTap(onBus: 0)
-        audioEngine.stop()
-        isRecording = false
-    }
-
-    private func setupAudioEngine() throws {
-        let inputNode = audioEngine.inputNode
-        let inputFormat = inputNode.outputFormat(forBus: 0)
-
-        guard inputFormat.sampleRate > 0 else {
+        guard format.sampleRate > 0 else {
             throw AudioCaptureError.noInputDevice
         }
 
-        guard let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: targetSampleRate,
-            channels: targetChannelCount,
-            interleaved: false
-        ) else {
-            throw AudioCaptureError.formatCreationFailed
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: format) { [weak self] buffer, _ in
+            self?.onAudioBuffer?(buffer)
         }
 
-        guard let converter = AVAudioConverter(from: inputFormat, to: targetFormat) else {
-            throw AudioCaptureError.converterCreationFailed
-        }
+        engine.prepare()
+        try engine.start()
 
-        let bufferSize: AVAudioFrameCount = 4096
-
-        inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat) {
-            [weak self] buffer, _ in
-            self?.processBuffer(buffer, converter: converter, targetFormat: targetFormat)
-        }
-
-        isSetup = true
+        audioEngine = engine
+        isRecording = true
     }
 
-    private func processBuffer(
-        _ buffer: AVAudioPCMBuffer,
-        converter: AVAudioConverter,
-        targetFormat: AVAudioFormat
-    ) {
-        let ratio = targetFormat.sampleRate / buffer.format.sampleRate
-        let outputFrameCapacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio)
+    public func stopRecording() {
+        guard isRecording, let engine = audioEngine else { return }
 
-        guard let outputBuffer = AVAudioPCMBuffer(
-            pcmFormat: targetFormat,
-            frameCapacity: outputFrameCapacity
-        ) else { return }
-
-        var error: NSError?
-        var inputConsumed = false
-
-        converter.convert(to: outputBuffer, error: &error) { _, outStatus in
-            if inputConsumed {
-                outStatus.pointee = .noDataNow
-                return nil
-            }
-            inputConsumed = true
-            outStatus.pointee = .haveData
-            return buffer
-        }
-
-        if error == nil, outputBuffer.frameLength > 0 {
-            onAudioBuffer?(outputBuffer)
-        }
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        audioEngine = nil
+        isRecording = false
     }
 }
 

--- a/Sources/CmdSpeak/Core/Engine/TranscriptionEngine.swift
+++ b/Sources/CmdSpeak/Core/Engine/TranscriptionEngine.swift
@@ -14,12 +14,12 @@ public struct TranscriptionResult: Sendable {
 }
 
 /// Protocol for transcription engines.
-public protocol TranscriptionEngine: AnyObject, Sendable {
+public protocol TranscriptionEngine: Actor {
     var isReady: Bool { get }
 
     func initialize() async throws
     func transcribe(audioSamples: [Float]) async throws -> TranscriptionResult
-    func unload()
+    func unload() async
 }
 
 /// Errors that can occur during transcription.


### PR DESCRIPTION
## Summary
Clean up code quality and fix Swift 6 concurrency warnings.

## Changes
- Convert WhisperKitEngine to actor for proper async/await concurrency
- Replace NSLock with DispatchQueue for thread-safe audio buffer access  
- Remove all debug print statements from production code
- Remove emoji characters from CLI output
- Simplify AudioCaptureManager implementation
- Add note about Terminal microphone permission requirement for CLI

## Testing
- `swift build -c release` - no warnings, no errors
- CmdSpeakApp launches and runs in menu bar
- CLI `cmdspeak status` works

## Note
The CLI `test-mic` command requires Terminal.app to have microphone permission in System Settings. The GUI app (CmdSpeakApp) handles permissions independently and is the primary usage path.