### PR TITLE
fix: Use CFRunLoopRun instead of dispatchMain

### DIFF
--- a/Sources/CmdSpeak/CLI/CmdSpeakCLI.swift
+++ b/Sources/CmdSpeak/CLI/CmdSpeakCLI.swift
@@ -172,6 +172,7 @@ struct Run: AsyncParsableCommand {
             Darwin.exit(0)
         }
 
-        dispatchMain()
+        // Keep the run loop running
+        CFRunLoopRun()
     }
 }


### PR DESCRIPTION
## Summary
Fix crash (trace trap) that occurs immediately after startup.

## Root Cause
`dispatchMain()` does not work correctly when called from an async context.

## Fix
Use `CFRunLoopRun()` instead, which properly runs the main run loop.

## Testing
- App starts and stays running
- No crash on startup

Fixes #16