### PR TITLE
docs: Clarify macOS Dictation shortcut setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ The app runs in the menu bar. On first launch:
 2. Grant **Accessibility** permission (System Settings > Privacy & Security > Accessibility)
 3. The Whisper model will download (~1.5GB for large-v3-turbo)
 
+**Before using, disable macOS Dictation shortcut:**
+- System Settings > Keyboard > Dictation > Shortcut > **Off**
+
 Once running:
 - Double-tap Right Command key to start dictating
 - Speak naturally

--- a/Sources/CmdSpeak/CLI/CmdSpeakCLI.swift
+++ b/Sources/CmdSpeak/CLI/CmdSpeakCLI.swift
@@ -166,7 +166,8 @@ struct Run: AsyncParsableCommand {
         print("Ready.")
         print("Double-tap Right Cmd to dictate. Ctrl+C to quit.")
         print("")
-        print("Note: Disable macOS Dictation shortcut in System Settings > Keyboard > Dictation")
+        print("Important: Set macOS Dictation Shortcut to 'Off':")
+        print("  System Settings > Keyboard > Dictation > Shortcut > Off")
 
         signal(SIGINT) { _ in
             Darwin.exit(0)


### PR DESCRIPTION
Clarify that users must set the Dictation **Shortcut** dropdown to 'Off', not just disable Dictation.

Fixes #18